### PR TITLE
fix: Avoid duplicate calls to decodingInfo()

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,8 +398,11 @@ class McEncryptionSchemePolyfill {
   /**
    * Call navigator.requestMediaKeySystemAccess to get the MediaKeySystemAccess
    * information.
+   *
    * @param {!MediaDecodingConfiguration} requestedConfiguration The requested
    *   decoding configuration.
+   * @return {!Promise.<!MediaKeySystemAccess>} A Promise to a
+   *   MediaKeySystemAccess instance.
    * @private
    */
   static async getMediaKeySystemAccess_(requestedConfiguration) {

--- a/index.js
+++ b/index.js
@@ -399,7 +399,8 @@ class McEncryptionSchemePolyfill {
    * Call navigator.requestMediaKeySystemAccess to get the MediaKeySystemAccess
    * information.
    * @param {!MediaDecodingConfiguration} requestedConfiguration The requested
-   * decoding configuration.
+   *   decoding configuration.
+   * @private
    */
   static async getMediaKeySystemAccess_(requestedConfiguration) {
     const mediaKeySystemConfig =


### PR DESCRIPTION
In `probeDecodingInfo_()`, if `navigator.mediaCapabilities` returns the decodingInfo results but has no keySystemAccess information for encrypted content, we can call `navigator.requestMediaKeySystemAccess` to patch the keySystemAccess information.

This avoids a few unnecessary calls of `decodingInfo`.

Built on abandoned PR #19 by @michellezhuogg 