### PR TITLE
fix: Use cbcs as default scheme for Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -561,7 +561,7 @@ function guessSupportedScheme(keySystem) {
   } else if (keySystem.startsWith('org.w3')) {
     return 'cenc';
   } else if (keySystem.startsWith('com.apple')) {
-    return 'cbcs-1-9';
+    return 'cbcs';
   }
 
   // We don't have this key system in our map!


### PR DESCRIPTION
Use cbcs instead cbcs-1-9 becuase the last is not supported in Safari: https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/encryptedmedia/MediaKeyEncryptionScheme.idl