### PR TITLE
fix(demo): Log demo errors to the console

### DIFF
--- a/demo/query.js
+++ b/demo/query.js
@@ -53,6 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.results.textContent =
           formatObjectToString(mksa.getConfiguration());
     } catch (error) {
+      console.log(error);
       window.results.textContent = formatObjectToString({error: error.message});
     }
   });  // emeRun click listener
@@ -113,6 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
             formatObjectToString(mksa.getConfiguration());
       }
     } catch (error) {
+      console.log(error);
       window.results.textContent = formatObjectToString({error: error.message});
     }
   });  // mcRun click listener


### PR DESCRIPTION
When a "request fails" in the demo, sometimes it is because of an exception elsewhere in the process.  This logs those errors to the console so that they can be traced and fixed.