### PR TITLE
fix: Fix conflicts with multiple installations

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ class EmeEncryptionSchemePolyfill {
    * @export
    */
   static install() {
-    if (EmeEncryptionSchemePolyfill.originalRMKSA_) {
+    if (EmeEncryptionSchemePolyfill.originalRMKSA_ ||
+        navigator['emeEncryptionSchemePolyfilled']) {
       console.debug('EmeEncryptionSchemePolyfill: Already installed.');
       return;
     }
@@ -53,6 +54,11 @@ class EmeEncryptionSchemePolyfill {
         'Waiting to detect encryptionScheme support.');
     navigator.requestMediaKeySystemAccess =
         EmeEncryptionSchemePolyfill.probeRMKSA_;
+
+    // Mark EME as polyfilled.  This keeps us from running into conflicts
+    // between multiple versions of this (compiled Shaka lib vs
+    // uncompiled source).
+    navigator['emeEncryptionSchemePolyfilled'] = true;
   }
 
   /**
@@ -240,7 +246,8 @@ class McEncryptionSchemePolyfill {
    * @export
    */
   static install() {
-    if (McEncryptionSchemePolyfill.originalDecodingInfo_) {
+    if (McEncryptionSchemePolyfill.originalDecodingInfo_ ||
+        navigator['mediaCapabilitiesEncryptionSchemePolyfilled']) {
       console.debug('McEncryptionSchemePolyfill: Already installed.');
       return;
     }
@@ -259,6 +266,11 @@ class McEncryptionSchemePolyfill {
         'Waiting to detect encryptionScheme support.');
     navigator.mediaCapabilities.decodingInfo =
         McEncryptionSchemePolyfill.probeDecodingInfo_;
+
+    // Mark MediaCapabilities as polyfilled.  This keeps us from running into
+    // conflicts between multiple versions of this (compiled Shaka lib vs
+    // uncompiled source).
+    navigator['mediaCapabilitiesEncryptionSchemePolyfilled'] = true;
   }
 
   /**


### PR DESCRIPTION
Most polyfills used in Shaka Player can be installed more than once, because they can check for the necessity of the polyfill synchronously.  This is not the case for eme-encryption-scheme-polyfill, which has to install a temporary shim to determine the need for a true polyfill on the first call.

This polyfill checked for a previous installation, but only using a static field on the class.  This system breaks in our test environment, where there can be multiple copies of the polyfill: one compiled into Shaka Player as an internal component, and one in source form for unit tests.  When both of these are installed at once, they couldn't detect each other because their private static fields were on distinct classes.

To resolve this, we attach bools to `navigator` that allow multiple versions of the polyfill to detect each other.  This fixes Shaka Player test failures and mistakenly skipped tests on some platforms.