### PR TITLE
ci: Do not persist credentials after checkout

### DIFF
--- a/.github/workflows/publish-demo.yaml
+++ b/.github/workflows/publish-demo.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Build
         run: npm ci && npm run build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: refs/tags/${{ steps.release.outputs.tag_name }}
+          persist-credentials: false
         if: ${{ steps.release.outputs.release_created }}
 
       - uses: actions/setup-node@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Test
         run: |


### PR DESCRIPTION
See actions/checkout#485 and https://johnstawinski.com/2024/01/11/playing-with-fire-how-we-executed-a-critical-supply-chain-attack-on-pytorch/

In short, it is a terrible idea to persist even our default credentials after checkout. There's no call for that, so we will now set `persist-credentials: false` on all checkout actions.